### PR TITLE
build(config): add tsconfig to opt out TS transpilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,17 +11,16 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "sourceMap": true,
+    "sourceMap": false,
+    "inlineSourceMap": false,
+    "isolatedModules": true,
     "declaration": false,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": [
-      "ES2022",
-      "dom"
-    ]
+    "lib": ["ES2022", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/realworld-angular/realworld-angular-starter/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

This PR modifies the `tsconfig.json` file to:
- Disable `sourceMap` and `inlineSourceMap`
- Enable `isolatedModules`

**New Behavior:**
These changes allow the TypeScript code to be transpiled directly via ESBuild, resulting in faster build times and optimized output. Specifically:
- **Source maps are disabled** to streamline the build process.
- **`isolatedModules` is enabled** to allow ESBuild to handle TypeScript transpilation more effectively, including optimizations like inlining enums.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
