### PR TITLE
refactor: run only on pushs from PR

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,10 @@
 name: Format Check
 
-on: [push, pull_request]
+on:
+  push:
+    types:
+      - pushed
+  pull_request:
 
 jobs:
   format-check:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,11 @@
 name: Playwright Tests
+
 on:
-  pull_request
+  push:
+    types:
+      - pushed
+  pull_request:
+
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -2,6 +2,8 @@ name: Lint CSS
 
 on:
   push:
+    types:
+      - pushed
   pull_request:
 
 jobs:


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/realworld-angular/realworld-angular-starter/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

run push workflows only on PRs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
